### PR TITLE
Implemented support for reading in Http Request Body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/src/JSONReform.php
+++ b/src/JSONReform.php
@@ -45,6 +45,23 @@ class JSONReform
     }
 
     /**
+     * Creates a new JsonReader instance from an HTTP Request Body
+     * 
+     * @return JsonReader The JsonReader instance created from the file.
+     * @throws InvalidArgumentException If the this fails reading from the http request body.
+     */
+    public static function fromHTTPRequestBody(): JsonReader 
+    {
+        $json = file_get_contents('php://input');
+
+        if($json === false) {
+            throw new InvalidArgumentException("Failed to read json from http request body");
+        }
+
+        return new self($json);
+    }
+
+    /**
      * Gets the value at the specified path in the JSON data.
      *
      * @param string $path The path to the value, in dot notation.

--- a/src/JSONReform.php
+++ b/src/JSONReform.php
@@ -23,13 +23,13 @@ class JSONReform
     }
 
     /**
-     * Creates a new JsonReader instance from a JSON file.
+     * Creates a new JsonReform instance from a JSON file.
      *
      * @param string $filename The path to the JSON file to read.
-     * @return JsonReader The JsonReader instance created from the file.
+     * @return JsonReform The JsonReform instance created from the file.
      * @throws InvalidArgumentException If the file does not exist or cannot be read.
      */
-    public static function fromFile(string $filename): JsonReader
+    public static function fromFile(string $filename): JsonReform
     {
         if (!is_file($filename) || !is_readable($filename)) {
             throw new InvalidArgumentException("File not found or cannot be read: $filename");
@@ -45,12 +45,12 @@ class JSONReform
     }
 
     /**
-     * Creates a new JsonReader instance from an HTTP Request Body
+     * Creates a new JsonReform instance from an HTTP Request Body
      * 
-     * @return JsonReader The JsonReader instance created from the file.
+     * @return JsonReform The JsonReform instance created from the file.
      * @throws InvalidArgumentException If the this fails reading from the http request body.
      */
-    public static function fromHTTPRequestBody(): JsonReader 
+    public static function fromHTTPRequestBody(): JsonReform 
     {
         $json = file_get_contents('php://input');
 


### PR DESCRIPTION
Added a new method that allows reading json string from an HTTP Request Body.

```php
$json = JsonReform::fromHTTPRequestBody();
```